### PR TITLE
Add functionality to replace the Maps API Key

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,6 +119,7 @@ dependencies {
     implementation("io.github.diamondminer88:zip-android:2.2.0@aar")
     implementation("com.github.iyxan23:zipalign-java:1.2.1")
     implementation("io.coil-kt.coil3:coil-gif:3.1.0")
+    implementation("io.github.reandroid:ARSCLib:1.3.5")
     compileOnly("org.bouncycastle:bcprov-jdk18on:1.80")
 }
 

--- a/app/src/main/java/com/grindrplus/manager/installation/Installation.kt
+++ b/app/src/main/java/com/grindrplus/manager/installation/Installation.kt
@@ -27,6 +27,7 @@ class Installation(
     val version: String,
     modUrl: String,
     grindrUrl: String,
+    private val mapsApiKey: String?
 ) {
     private val keyStoreUtils = KeyStoreUtils(context)
     private val folder = context.getExternalFilesDir(null)
@@ -37,7 +38,7 @@ class Installation(
     private val bundleFile = File(folder, "grindr-$version.zip")
 
     private val installStep = InstallApkStep(outputDir)
-    private val patchApkStep = PatchApkStep(unzipFolder, outputDir, modFile, keyStoreUtils.keyStore)
+    private val patchApkStep = PatchApkStep(unzipFolder, outputDir, modFile, keyStoreUtils.keyStore, mapsApiKey)
     private val commonSteps = listOf(
         // Order matters
         CheckStorageSpaceStep(folder),
@@ -79,7 +80,7 @@ class Installation(
         steps = listOf(
             CheckStorageSpaceStep(folder),
             ExtractBundleStep(bundleFile, unzipFolder),
-            PatchApkStep(unzipFolder, outputDir, modFile, keyStoreUtils.keyStore),
+            PatchApkStep(unzipFolder, outputDir, modFile, keyStoreUtils.keyStore, mapsApiKey),
             InstallApkStep(outputDir)
         ),
         operationName = "custom_install",

--- a/app/src/main/java/com/grindrplus/manager/installation/steps/PatchApkStep.kt
+++ b/app/src/main/java/com/grindrplus/manager/installation/steps/PatchApkStep.kt
@@ -3,6 +3,8 @@ package com.grindrplus.manager.installation.steps
 import android.content.Context
 import com.grindrplus.manager.installation.BaseStep
 import com.grindrplus.manager.installation.Print
+import com.reandroid.apk.ApkModule
+import com.reandroid.xml.StyleDocument
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.lsposed.patch.LSPatch
@@ -15,24 +17,42 @@ class PatchApkStep(
     private val unzipFolder: File,
     private val outputDir: File,
     private val modFile: File,
-    private val keyStore: File
+    private val keyStore: File,
+    private val customMapsApiKey: String?
 ) : BaseStep() {
     override val name = "Patching Grindr APK"
+
+    private companion object {
+        const val MAPS_API_KEY_NAME = "com.google.android.geo.API_KEY"
+    }
 
     override suspend fun doExecute(context: Context, print: Print) {
         print("Cleaning output directory...")
         outputDir.listFiles()?.forEach { it.delete() }
 
-        val apkFiles = unzipFolder.listFiles()
-            ?.filter { it.name.endsWith(".apk") && it.exists() && it.length() > 0 }
-            ?.map { it.absolutePath }
-            ?.toTypedArray()
+        val apkFiles = unzipFolder.listFiles()?.filter { it.name.endsWith(".apk") && it.exists() && it.length() > 0 }
 
         if (apkFiles.isNullOrEmpty()) {
             throw IOException("No valid APK files found to patch")
         }
 
+        if (customMapsApiKey != null) {
+            print("Overwriting Maps API Key")
+            val baseApk = if (apkFiles.size == 1) apkFiles.first() else apkFiles.first { it.name == "base.apk" }
+            val apkModule = ApkModule.loadApkFile(baseApk)
+            val mapsApiKeyElement = apkModule.androidManifest.applicationElement.getElements { element ->
+                element.name == "meta-data" && element.searchAttributeByName("name").valueString == MAPS_API_KEY_NAME
+            }.next()
+            val valueAttribute = mapsApiKeyElement.searchAttributeByName("value")
+            print("Found existing API Key: ${valueAttribute.valueString}")
+            print("Overwriting with: $customMapsApiKey")
+            valueAttribute.setValueAsString(StyleDocument.parseStyledString(customMapsApiKey))
+            apkModule.writeApk(baseApk)
+        }
+
         print("Starting LSPatch process with ${apkFiles.size} APK files")
+
+        val apkFilePaths = apkFiles.map { it.absolutePath }.toTypedArray()
 
         val logger = object : Logger() {
             override fun d(message: String?) {
@@ -54,7 +74,7 @@ class PatchApkStep(
         withContext(Dispatchers.IO) {
             LSPatch(
                 logger,
-                *apkFiles,
+                *apkFilePaths,
                 "-o", outputDir.absolutePath,
                 "-l", "2",
                 "-f",

--- a/app/src/main/java/com/grindrplus/manager/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/grindrplus/manager/settings/SettingsViewModel.kt
@@ -58,6 +58,19 @@ class SettingsViewModel(
 
                 val otherSettings = mutableListOf(
                     TextSetting(
+                        id = "maps_api_key",
+                        title = "Maps API Key",
+                        description = "Use a custom Maps API Key when using Grindr Plus with LSPatch",
+                        value = Config.get("maps_api_key", "") as String,
+                        onValueChange = {
+                            viewModelScope.launch {
+                                Config.put("maps_api_key", it)
+                                loadSettings()
+                            }
+                        },
+                        validator = { null }
+                    ),
+                    TextSetting(
                         id = "command_prefix",
                         title = "Command Prefix",
                         description = "Change the command prefix (default: /)",

--- a/app/src/main/java/com/grindrplus/manager/ui/InstallScreen.kt
+++ b/app/src/main/java/com/grindrplus/manager/ui/InstallScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.grindrplus.core.Config
 import com.grindrplus.core.Constants.GRINDR_PACKAGE_NAME
 import com.grindrplus.core.Logger
 import com.grindrplus.manager.DATA_URL
@@ -94,11 +95,16 @@ fun InstallPage(context: Activity, innerPadding: PaddingValues) {
 
     LaunchedEffect(selectedVersion) {
         if (selectedVersion == null) return@LaunchedEffect
+
+        val mapsApiKey = (Config.get("maps_api_key", "") as String).ifBlank { null }
+
+
         installation = Installation(
             context,
             selectedVersion!!.modVer,
             selectedVersion!!.modUrl,
-            selectedVersion!!.grindrUrl
+            selectedVersion!!.grindrUrl,
+            mapsApiKey
         )
     }
 
@@ -143,11 +149,14 @@ fun InstallPage(context: Activity, innerPadding: PaddingValues) {
                 val bundleFile = createTempFileFromUri(context, customBundleUri!!, "grindr-$customVersionName.zip")
                 val modFile = createTempFileFromUri(context, customModUri!!, "mod-$customVersionName.zip")
 
+                val mapsApiKey = (Config.get("maps_api_key", "") as String).ifBlank { null }
+
                 val customInstallation = Installation(
                     context,
                     customVersionName,
                     modFile.absolutePath,
-                    bundleFile.absolutePath
+                    bundleFile.absolutePath,
+                    mapsApiKey
                 )
 
                 withContext(Dispatchers.IO) {
@@ -572,11 +581,14 @@ private fun startInstallation(
 
     activityScope.launch {
         try {
+            val mapsApiKey = (Config.get("maps_api_key", "") as String).ifBlank { null }
+
             val installation = Installation(
                 context,
                 version.modVer,
                 version.modUrl,
-                version.grindrUrl
+                version.grindrUrl,
+                mapsApiKey
             )
 
             withContext(Dispatchers.IO) {


### PR DESCRIPTION
This new feature allows the user to specify a custom API Key for Google Maps when using Grindr Plus with LSPatch. The original API key used by Grindr is restricted to the original package signature. When using LSPatch, the signature changes, which impairs the functionality of features such as Explore, location sharing and the teleport command. API keys can be created using the [Google Cloud Console](https://console.cloud.google.com/google/maps-apis/credentials). Providing a credit card is required, however, the free quota should be more than enough for a single user. Using an unrestricted API key is probably the easiest solution as there is currently no logic to display the new signature and the signing key is also very short-lived (30 days).