### PR TITLE
Fix: Resolve stuck notification permission dialog

### DIFF
--- a/app/src/main/java/com/grindrplus/manager/MainActivity.kt
+++ b/app/src/main/java/com/grindrplus/manager/MainActivity.kt
@@ -90,6 +90,7 @@ import kotlinx.coroutines.cancel
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 
+
 internal val activityScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 internal const val TAG = "GrindrPlus"
 internal const val DATA_URL =
@@ -124,7 +125,7 @@ class MainActivity : ComponentActivity() {
         val showUninstallDialog = mutableStateOf(false)
     }
 
-    private var showPermissionDialog = false
+    private var showPermissionDialog by mutableStateOf(false)
     private lateinit var receiver: NotificationActionReceiver
 
     private val requestPermissionLauncher = registerForActivityResult(
@@ -149,7 +150,7 @@ class MainActivity : ComponentActivity() {
                 }
 
                 shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
-                    showNotificationPermissionExplanation()
+                    showPermissionDialog = true
                 }
 
                 else -> {
@@ -174,10 +175,6 @@ class MainActivity : ComponentActivity() {
             ).show()
             startActivity(intent)
         }
-    }
-
-    private fun showNotificationPermissionExplanation() {
-        showPermissionDialog = true
     }
 
     private fun registerNotificationReceiver() {


### PR DESCRIPTION
Fixes #128 

This PR resolves an issue where the in-app notification permission dialog would become unresponsive if the user had previously denied the permission manually through system settings.

### The Problem
The dialog's visibility was controlled by a standard boolean variable. Changing this variable did not trigger a recomposition in Jetpack Compose, leaving the dialog stuck on the screen even after its buttons were clicked.

### The Solution
This fix addresses the problem in two ways:

- State Management Fix: The `showPermissionDialogvariable` has been converted to a proper Compose state using `by mutableStateOf(false)`. This ensures that any changes to its value correctly trigger a UI update, allowing the dialog to be dismissed.

- Code Refactoring: The now redundant `showNotificationPermissionExplanation()` function was removed, and its logic was moved directly into the `when` block where it is called.