### PR TITLE
fixes loading screen often being stuck in Install section due to app not handling state correctly

### DIFF
--- a/app/src/main/java/com/grindrplus/manager/ui/HttpClient.kt
+++ b/app/src/main/java/com/grindrplus/manager/ui/HttpClient.kt
@@ -1,0 +1,12 @@
+package com.grindrplus.manager.ui
+
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+// A single, shared client for the entire app to use.
+object HttpClient {
+    val instance: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(15, TimeUnit.SECONDS)
+        .build()
+}

--- a/app/src/main/java/com/grindrplus/manager/ui/InstallScreenViewModel.kt
+++ b/app/src/main/java/com/grindrplus/manager/ui/InstallScreenViewModel.kt
@@ -1,0 +1,103 @@
+package com.grindrplus.manager.ui
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.grindrplus.core.Logger
+import com.grindrplus.manager.DATA_URL
+import okhttp3.Request
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.IOException
+
+class InstallScreenViewModel : ViewModel() {
+
+    private val _isLoading = MutableStateFlow(true)
+    val isLoading = _isLoading.asStateFlow()
+
+    private val _loadingText = MutableStateFlow("Loading available versions...")
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage = _errorMessage.asStateFlow()
+
+    val versionData = mutableStateListOf<Data>()
+
+    fun loadVersionData(manifestUrl: String) {
+        _isLoading.value = true
+        _errorMessage.value = null
+        viewModelScope.launch {
+            // Update loading text after 10 seconds of waiting
+            val textUpdateJob = launch {
+                delay(10000)
+                _loadingText.value = "Still loading... Check your internet connectivity."
+            }
+
+            val result = withContext(Dispatchers.IO) {
+                fetchVersions(manifestUrl)
+            }
+
+            textUpdateJob.cancel() // Cancel the text update job once loading is done
+
+            if (result.isSuccess) {
+                versionData.clear()
+                versionData.addAll(result.getOrThrow())
+                Logger.d("Found ${versionData.size} available versions")
+            } else {
+                _errorMessage.value = result.exceptionOrNull()?.localizedMessage ?: "Unknown error"
+                Logger.e("Error loading version data: ${_errorMessage.value}")
+            }
+            _isLoading.value = false
+        }
+    }
+
+    private fun fetchVersions(manifestUrl: String): Result<List<Data>> {
+        val client = HttpClient.instance
+        val maxRetries = 3
+        var lastException: Exception? = null
+
+        for (attempt in 1..maxRetries) {
+            try {
+                Logger.d("Loading version data from $manifestUrl (Attempt $attempt/$maxRetries)")
+                val request = Request.Builder().url(manifestUrl).build()
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) throw IOException("Server error: ${response.code}")
+                    val body = response.body?.string() ?: throw IOException("Empty response body")
+                    return Result.success(parseVersionData(body))
+                }
+            } catch (e: Exception) {
+                lastException = e
+                Logger.e("Attempt $attempt failed: ${e.message}")
+                if (attempt < maxRetries) Thread.sleep(2000) // Use sleep for non-coroutine delay
+            }
+        }
+        return Result.failure(lastException ?: IOException("Unknown error after $maxRetries retries"))
+    }
+
+    private fun parseVersionData(jsonData: String): List<Data> {
+        return try {
+            val result = mutableListOf<Data>()
+            val jsonObject = JSONObject(jsonData)
+            jsonObject.keys().forEach { key ->
+                val jsonArray = jsonObject.getJSONArray(key)
+                if (jsonArray.length() >= 2) {
+                    result.add(
+                        Data(
+                            modVer = key,
+                            grindrUrl = jsonArray.getString(0),
+                            modUrl = jsonArray.getString(1)
+                        )
+                    )
+                }
+            }
+            result.sortedByDescending { it.modVer }
+        } catch (e: JSONException) {
+            throw IOException("Invalid data format: ${e.localizedMessage}")
+        }
+    }
+}


### PR DESCRIPTION
### Description

This PR refactors the InstallScreen.kt in Manager app to use a modern MVVM (Model-View-ViewModel) architecture. This resolves the loading screen being stuck bug and improves the code's structure.

The original implementation managed all its state and network logic directly within the composable using activityScope that led to a stability issue where the app's loading process would get stuck if the user closed and reopened the app without a force-close.

### Changes Made

- [ ] InstallViewModel.kt created:

A new InstallViewModel is introduced to handle all business logic and state management. It uses viewModelScope, which is lifecycle-aware, ensuring that network requests are automatically cancelled when the screen is closed, fixing the "stuck" bug.

- [ ] HttpClient.kt Cceated:

The OkHttpClient instance has been extracted into a singleton HttpClient object.
  
- [ ] InstallScreen.kt refactored:

I cleaned the code a bit and made UI code logic stateless.