### PR TITLE
Bug workaround: DisableUpdates: use static version info

### DIFF
--- a/app/src/main/java/com/grindrplus/hooks/DisableUpdates.kt
+++ b/app/src/main/java/com/grindrplus/hooks/DisableUpdates.kt
@@ -54,28 +54,40 @@ class DisableUpdates : Hook(
     }
 
     private fun fetchLatestVersionInfo() {
-        val client = OkHttpClient()
-        val request = Request.Builder()
-            .url(versionInfoEndpoint).build()
+//        val client = OkHttpClient()
+//        val request = Request.Builder()
+//            .url(versionInfoEndpoint).build()
 
-        try {
-            val response = client.newCall(request).execute()
-            if (response.isSuccessful) {
-                val jsonData = response.body?.string()
-                if (jsonData != null) {
-                    val json = JSONObject(jsonData)
-                    versionCode = json.getInt("versionCode")
-                    versionName = json.getString("versionName")
-                    logd("Successfully fetched version info: $versionName ($versionCode)")
-                    updateVersionInfo()
-                }
-            } else {
-                loge("Failed to fetch version info: ${response.message}")
-            }
-        } catch (e: Exception) {
-            loge("Error fetching version info: ${e.message}")
-            Logger.writeRaw(e.stackTraceToString())
-        }
+//		try {
+//			val response = client.newCall(request).execute()
+//			if (response.isSuccessful) {
+//				val jsonData = response.body?.string()
+//				if (jsonData != null) {
+//					val json = JSONObject(jsonData)
+//					versionCode = json.getInt("versionCode")
+//					versionName = json.getString("versionName")
+//					logd("Successfully fetched version info: $versionName ($versionCode)")
+//					updateVersionInfo()
+//				}
+//			} else {
+//				loge("Failed to fetch version info: ${response.message}")
+//			}
+//		} catch (e: Exception) {
+//			loge("Error fetching version info: ${e.message}")
+//			Logger.writeRaw(e.stackTraceToString())
+//		}
+
+
+		try {
+			versionCode = 147239
+			versionName = "25.20.0"
+			logd("Fake fetched version info: $versionName ($versionCode)")
+			updateVersionInfo()
+
+		} catch (e: Exception) {
+			loge("Error fetching version info: ${e.message}")
+			Logger.writeRaw(e.stackTraceToString())
+		}
     }
 
     private fun compareVersions(v1: String, v2: String): Int {


### PR DESCRIPTION
Bug workaround: version spoofing does not work correctly, because the fetching takes too long and therefore hook are executed too late to have an effect.

I have removed the fetching and hardcoded the version to 25.20.0.147239