### PR TITLE
Fix for Unlimited Albums

### DIFF
--- a/app/src/main/java/com/grindrplus/persistence/mappers/AlbumMapper.kt
+++ b/app/src/main/java/com/grindrplus/persistence/mappers/AlbumMapper.kt
@@ -12,7 +12,7 @@ import java.lang.Long.parseLong
 
 private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
 
-private const val ALBUM_CLASS = "com.grindrapp.android.model.Album"
+private const val ALBUM_CLASS = "com.grindrapp.android.chat.domain.model.Album"
 private const val ALBUM_BRIEF_CLASS = "com.grindrapp.android.model.albums.AlbumBrief"
 private const val ALBUM_CONTENT_CLASS = "com.grindrapp.android.chat.domain.model.AlbumContent"
 


### PR DESCRIPTION
What was broken?

Unlimited Albums was broken inside the handleGetAlbum function.

The issue inside the function was it was trying to parseAlbumContent.
Inside the parseAlbumContent function, it does 
                    val grindrAlbumContentList =
                        albumContentEntities.map { it.toGrindrAlbumContent() }

but when it tried to call the toGrindrAlbumContent it failed since the toGrindrAlbumContent tried to load the class stored in ALBUM_CONTENT_CLASS which didn't exist.

How did I fix?

I just searched the AlbumContent and seen the path was different, changed the path and it works :) 

// supported version: 25.20.0