### PR TITLE
fix apksign and patch steps in wrong order

### DIFF
--- a/app/src/main/java/com/grindrplus/manager/installation/Installation.kt
+++ b/app/src/main/java/com/grindrplus/manager/installation/Installation.kt
@@ -67,9 +67,9 @@ class Installation(
                 appName = appName,
                 debuggable = debuggable,
             ),
-            SignClonedGrindrApk(keyStoreUtils, unzipFolder),
             PatchApkStep(unzipFolder, outputDir, modFile,
                 keyStoreUtils.keyStore, mapsApiKey, embedLSpatch),
+            SignClonedGrindrApk(keyStoreUtils, outputDir),
             installStep
         ),
         operationName = "clone",


### PR DESCRIPTION
the cloning process used wrong order of steps, it first signed the apk then modified it, resulting in an unsigned apk