### PR TITLE
Fix: invisible compass/location button on cloned APKs

### DIFF
--- a/app/src/main/java/com/grindrplus/ui/Utils.kt
+++ b/app/src/main/java/com/grindrplus/ui/Utils.kt
@@ -7,7 +7,6 @@ import android.graphics.drawable.GradientDrawable
 import android.widget.Toast
 import com.grindrplus.GrindrPlus
 import com.grindrplus.core.Config
-import com.grindrplus.core.Constants
 import com.grindrplus.core.Logger
 import java.time.Instant
 import java.time.LocalDateTime
@@ -16,7 +15,7 @@ import java.time.format.DateTimeFormatter
 
 object Utils {
     fun getId(name: String, defType: String, context: Context): Int {
-        return context.resources.getIdentifier(name, defType, Constants.GRINDR_PACKAGE_NAME)
+        return context.resources.getIdentifier(name, defType, context.packageName)
     }
 
     fun createButtonDrawable(color: Int): GradientDrawable {


### PR DESCRIPTION
### The Problem

`Utils.getId()` uses `Constants.GRINDR_PACKAGE_NAME` (hardcoded `"com.grindrapp.android"`) as the package parameter for `context.resources.getIdentifier()`. Cloned APKs have a different package name (e.g. `"com.grindrapp.android.one"`), so `getIdentifier()` returns `0` — causing any resource lookup via `getId()` to silently fail.

The most visible symptom is the compass/location button injected by `LocationSpoofer` into the chat toolbar: the `ImageButton` gets no drawable and no ripple background, rendering it completely invisible on all clone installs.

### The Fix

Replace the hardcoded constant with `context.packageName`, which correctly resolves to the actual runtime package name for both original and cloned installs:

```kotlin
// Before
context.resources.getIdentifier(name, defType, Constants.GRINDR_PACKAGE_NAME)

// After
context.resources.getIdentifier(name, defType, context.packageName)
```

### Affected callers

| Caller | Resource looked up | Impact on clones |
|---|---|---|
| `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofer` || `LocationSpoofeE_NAME` in `getId()` |

Fixes #253