### PR TITLE
Remove unnecessary DexClassLoader and module APK copy

### DIFF
--- a/app/src/main/java/com/grindrplus/GrindrPlus.kt
+++ b/app/src/main/java/com/grindrplus/GrindrPlus.kt
@@ -28,7 +28,6 @@ import com.grindrplus.utils.HookManager
 import com.grindrplus.utils.PCHIP
 import com.grindrplus.utils.HookStage
 import com.grindrplus.utils.hookConstructor
-import dalvik.system.DexClassLoader
 import de.robv.android.xposed.XposedHelpers.getObjectField
 import de.robv.android.xposed.XposedHelpers.callMethod
 import kotlinx.coroutines.CoroutineScope
@@ -43,7 +42,6 @@ import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONArray
 import org.json.JSONObject
-import java.io.File
 import java.io.IOException
 import java.lang.ref.WeakReference
 import kotlin.system.measureTimeMillis
@@ -127,7 +125,7 @@ object GrindrPlus {
 
     val serverNotifications = EventManager.serverNotifications
 
-    fun init(modulePath: String, application: Application,
+    fun init(application: Application,
              versionCodes: IntArray, versionNames: Array<String>) {
 
         if (isInitialized) {
@@ -161,12 +159,12 @@ object GrindrPlus {
         }
 
         Config.initialize(application.packageName)
-        val newModule = File(context.filesDir, "grindrplus.dex")
-        File(modulePath).copyTo(newModule, true)
-        newModule.setReadOnly()
 
-        this.classLoader =
-            DexClassLoader(newModule.absolutePath, null, null, context.classLoader)
+        // Legacy cleanup: remove the grindrplus.dex file that was unnecessarily copied on every launch.
+        // This line can be removed in a future version once all users have updated.
+        context.filesDir.resolve("grindrplus.dex").delete()
+
+        this.classLoader = context.classLoader
         this.database = GPDatabase.create(context)
         this.hookManager = HookManager()
         this.instanceManager = InstanceManager(classLoader)

--- a/app/src/main/java/com/grindrplus/XposedLoader.kt
+++ b/app/src/main/java/com/grindrplus/XposedLoader.kt
@@ -8,18 +8,11 @@ import com.grindrplus.hooks.sslUnpinning
 import com.grindrplus.utils.HookStage
 import com.grindrplus.utils.hook
 import de.robv.android.xposed.IXposedHookLoadPackage
-import de.robv.android.xposed.IXposedHookZygoteInit
 import de.robv.android.xposed.XC_MethodReplacement
 import de.robv.android.xposed.XposedHelpers.findAndHookMethod
 import de.robv.android.xposed.callbacks.XC_LoadPackage
 
-class XposedLoader : IXposedHookZygoteInit, IXposedHookLoadPackage {
-    private lateinit var modulePath: String
-
-    override fun initZygote(startupParam: IXposedHookZygoteInit.StartupParam) {
-        modulePath = startupParam.modulePath
-    }
-
+class XposedLoader : IXposedHookLoadPackage {
     override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
         if (lpparam.packageName.startsWith("com.grindrplus")) {
             findAndHookMethod(
@@ -39,7 +32,7 @@ class XposedLoader : IXposedHookZygoteInit, IXposedHookLoadPackage {
 
         Application::class.java.hook("attach", HookStage.AFTER) {
             val application = it.thisObject()
-            GrindrPlus.init(modulePath, application,
+            GrindrPlus.init(application,
                 BuildConfig.TARGET_GRINDR_VERSION_CODES,
                 BuildConfig.TARGET_GRINDR_VERSION_NAMES)
         }


### PR DESCRIPTION
The `DexClassLoader` was originally added with the idea of accessing module classes at runtime in LSPatch, but it never worked. The module APK has multiple `dex` files and neither `DexClassLoader` nor `PathClassLoader` can load classes from secondary `dex` files in this context. Classes from `classes.dex` are found, but nothing beyond that.

On top of that, the module APK cannot be loaded directly from the LSPatch cache because ART rejects writable `dex` files with a `SecurityException`, and the read-only copy in `filesDir` has the same multidex problem.

In both LSPosed and LSPatch, all `GrindrPlus.loadClass()` calls (including `Hook.findClass()`, which delegates to it) only ever resolve Grindr's obfuscated classes, which are always available via `context.classLoader`. The `DexClassLoader` just delegated everything to its parent anyway.

There is no real need to resolve module classes at runtime either. The only known case is `isLSPosed()`, but that is handled exclusively by LSPosed by hooking the module itself, not Grindr.

> [!NOTE]
> Also removes `IXposedHookZygoteInit` since `modulePath` is no longer needed, and adds a one-time cleanup of the legacy `grindrplus.dex` file from `filesDir`.