### PR TITLE
Remove isRooted() and drop RootBeer dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,7 +116,6 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.fetch2)
     implementation(libs.fetch2okhttp)
-    implementation(libs.rootbeer.lib)
     implementation(libs.zip.android) {
         artifact {
             type = "aar"

--- a/app/src/main/aidl/com/grindrplus/bridge/IBridgeService.aidl
+++ b/app/src/main/aidl/com/grindrplus/bridge/IBridgeService.aidl
@@ -11,7 +11,6 @@ interface IBridgeService {
     void deleteForcedLocation(String packageName);
     void logBlockEvent(String profileId, String displayName, boolean isBlock, String packageName);
     String getBlockEvents();
-    boolean isRooted();
     boolean isLSPosed();
     void clearBlockEvents();
     void sendNotification(String title, String message, int notificationId, String channelId, String channelName, String channelDescription);

--- a/app/src/main/java/com/grindrplus/bridge/BridgeClient.kt
+++ b/app/src/main/java/com/grindrplus/bridge/BridgeClient.kt
@@ -581,24 +581,6 @@ class BridgeClient(private val context: Context) {
         }
     }
 
-    fun isRooted(): Boolean {
-        if (!isBound.get()) {
-            if (connectBlocking(3000)) {
-                Logger.d("Connected to service on-demand for isRooted", LogSource.BRIDGE)
-            } else {
-                Logger.w("Cannot check root status, service not bound", LogSource.BRIDGE)
-                return false
-            }
-        }
-
-        return try {
-            bridgeService?.isRooted() ?: false
-        } catch (e: Exception) {
-            Logger.e("Error checking root status: ${e.message}", LogSource.BRIDGE)
-            false
-        }
-    }
-
     fun isLSPosed(): Boolean {
         if (!isBound.get()) {
             if (connectBlocking(3000)) {

--- a/app/src/main/java/com/grindrplus/bridge/BridgeService.kt
+++ b/app/src/main/java/com/grindrplus/bridge/BridgeService.kt
@@ -384,10 +384,6 @@ class BridgeService : Service() {
             }
         }
 
-        override fun isRooted(): Boolean {
-            return com.grindrplus.manager.utils.isRooted(applicationContext)
-        }
-
         override fun isLSPosed(): Boolean {
             return com.grindrplus.manager.utils.isLSPosed()
         }

--- a/app/src/main/java/com/grindrplus/hooks/StatusDialog.kt
+++ b/app/src/main/java/com/grindrplus/hooks/StatusDialog.kt
@@ -76,7 +76,6 @@ class StatusDialog : Hook(
 
                 if (GrindrPlus.bridgeClient.isConnected()) {
                     val isLSPosed = GrindrPlus.bridgeClient.isLSPosed()
-                    val isRooted = GrindrPlus.bridgeClient.isRooted()
                 }
 
                 val message = buildString {
@@ -92,7 +91,6 @@ class StatusDialog : Hook(
                     appendLine("• Bridge Status: $bridgeStatus")
                     if (GrindrPlus.bridgeClient.isConnected()) {
                         appendLine("• LSPosed: ${GrindrPlus.bridgeClient.isLSPosed()}")
-                        appendLine("• Rooted: ${GrindrPlus.bridgeClient.isRooted()}")
                     }
                     appendLine()
                     appendLine("Device Information:")

--- a/app/src/main/java/com/grindrplus/manager/ui/InstallScreen.kt
+++ b/app/src/main/java/com/grindrplus/manager/ui/InstallScreen.kt
@@ -53,7 +53,6 @@ import com.grindrplus.manager.ui.components.MessageBanner
 import com.grindrplus.manager.ui.components.VersionSelector
 import com.grindrplus.manager.utils.ErrorHandler
 import com.grindrplus.manager.utils.StorageUtils
-import com.scottyab.rootbeer.RootBeer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -76,11 +75,11 @@ fun InstallPage(context: Activity, innerPadding: PaddingValues, viewModel: Insta
     var isInstalling by remember { mutableStateOf(false) }
     var isCloning by remember { mutableStateOf(false) }
     var installationSuccessful by remember { mutableStateOf(false) }
-    val isRooted = remember { RootBeer(context).isRooted }
+    val isLSPosed = remember { isLSPosed() }
     var showCloneDialog by remember { mutableStateOf(false) }
     var installation by remember { mutableStateOf<Installation?>(null) }
     var warningBannerVisible by remember { mutableStateOf(true) }
-    var rootedBannerVisible by remember { mutableStateOf(isRooted) }
+    var lsposedBannerVisible by remember { mutableStateOf(isLSPosed) }
     var showCustomFileDialog by remember { mutableStateOf(false) }
     var useCustomFiles by remember { mutableStateOf(false) }
     var customVersionName by remember { mutableStateOf("custom") }
@@ -240,14 +239,14 @@ fun InstallPage(context: Activity, innerPadding: PaddingValues, viewModel: Insta
                 onDismiss = { warningBannerVisible = false }
             )
 
-            if (isLSPosed()) {
+            if (isLSPosed) {
                 MessageBanner(
                     text = "We detected that you are using LSPosed. Only use this screen to create clones, not to install the modded Grindr.",
-                    isVisible = rootedBannerVisible,
+                    isVisible = lsposedBannerVisible,
                     isPulsating = true,
                     modifier = Modifier.fillMaxWidth(),
                     type = BannerType.ERROR,
-                    onDismiss = { rootedBannerVisible = false }
+                    onDismiss = { lsposedBannerVisible = false }
                 )
             }
 

--- a/app/src/main/java/com/grindrplus/manager/utils/FileOperationHandler.kt
+++ b/app/src/main/java/com/grindrplus/manager/utils/FileOperationHandler.kt
@@ -7,7 +7,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import com.grindrplus.core.Constants.GRINDR_PACKAGE_NAME
 import com.grindrplus.core.Logger
-import com.scottyab.rootbeer.RootBeer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -141,7 +140,7 @@ object FileOperationHandler {
                 put("version", Build.VERSION.RELEASE)
                 put("sdk_level", Build.VERSION.SDK_INT)
                 put("security_patch", Build.VERSION.SECURITY_PATCH)
-                put("is_rooted", RootBeer(context).isRooted)
+                put("is_lsposed", isLSPosed())
             }
             mainJson.put("android", androidSection)
 

--- a/app/src/main/java/com/grindrplus/manager/utils/MiscUtils.kt
+++ b/app/src/main/java/com/grindrplus/manager/utils/MiscUtils.kt
@@ -2,7 +2,6 @@ package com.grindrplus.manager.utils
 
 import android.content.Context
 import android.content.Intent
-import com.scottyab.rootbeer.RootBeer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.net.Socket
@@ -24,15 +23,6 @@ suspend fun uploadAndShare(text: String, context: Context) {
     val shareIntent =
         Intent.createChooser(sendIntent, "Share installation logs")
     context.startActivity(shareIntent)
-}
-
-fun isRooted(context: Context): Boolean {
-    return try {
-        RootBeer(context).isRooted
-    } catch (e: Exception) {
-        e.printStackTrace()
-        false
-    }
 }
 
 fun isLSPosed(): Boolean {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,6 @@ room = "2.7.0"
 appcompat = "1.7.0"
 coordinatorlayout = "1.3.0"
 material = "1.12.0"
-rootbeerLib = "0.1.1"
 runtimeAndroid = "1.7.8"
 timber = "5.0.1"
 zipalignJava = "1.2.1"
@@ -47,7 +46,6 @@ compose-markdown = { module = "com.github.jeziellago:compose-markdown", version.
 fetch2 = { module = "com.github.tonyofrancis.Fetch:fetch2", version.ref = "fetch2" }
 fetch2okhttp = { module = "com.github.tonyofrancis.Fetch:fetch2okhttp", version.ref = "fetch2okhttp" }
 plausible-android-sdk = { module = "com.github.Rattlyy:plausible-android-sdk", version.ref = "plausibleAndroidSdk" }
-rootbeer-lib = { module = "com.scottyab:rootbeer-lib", version.ref = "rootbeerLib" }
 square-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }


### PR DESCRIPTION
GrindrPlus only needs to know whether it's running via LSPosed or LSPatch. `isLSPosed()` already provides that information, making `isRooted()` redundant.

Removes `isRooted()` from `MiscUtils.kt`, `BridgeClient.kt`, `BridgeService.kt` and `IBridgeService.aidl`, replaces `RootBeer` usages with `isLSPosed()` in `InstallScreen.kt` and `FileOperationHandler.kt`, and drops the RootBeer dependency from `build.gradle.kts` and `libs.versions.toml`.