### PR TITLE
fix: wrong parameter index for `isFeet` in `DistanceUtils` hook

### DIFF
--- a/app/src/main/java/com/grindrplus/hooks/ProfileDetails.kt
+++ b/app/src/main/java/com/grindrplus/hooks/ProfileDetails.kt
@@ -164,7 +164,7 @@ class ProfileDetails : Hook(
         findClass(distanceUtils).hook("c", HookStage.AFTER) { param ->
             val distance = param.arg<Double>(1)
             // val isAbbreviated = param.arg<Boolean>(3)
-            val isFeet = param.arg<Boolean>(0)
+            val isFeet = param.arg<Boolean>(2)
 
             param.setResult(
                 if (isFeet) {


### PR DESCRIPTION
The `DistanceUtils.c() `hook was using param index `0` (abbreviated flag) 
instead of index `2` (imperial flag) to determine the unit system.

This caused:
- Profile details to always show metric (`z = false` for full format)
- Viewed me profile items to always show imperial (`z = true` for abbreviated format)

regardless of the user's unit system setting.

<img width="1310" height="507" alt="image" src="https://github.com/user-attachments/assets/c5ad005a-1123-4e38-a340-e7f99aeee6e7" />
