### PR TITLE
feat: improve distance formatting in `DistanceUtils` hook

### DIFF
--- a/app/src/main/java/com/grindrplus/hooks/ProfileDetails.kt
+++ b/app/src/main/java/com/grindrplus/hooks/ProfileDetails.kt
@@ -162,24 +162,34 @@ class ProfileDetails : Hook(
         }
 
         findClass(distanceUtils).hook("c", HookStage.AFTER) { param ->
+            val isAbbreviated = param.arg<Boolean>(0)
             val distance = param.arg<Double>(1)
-            // val isAbbreviated = param.arg<Boolean>(3)
-            val isFeet = param.arg<Boolean>(2)
+            val isImperial = param.arg<Boolean>(2)
 
             param.setResult(
-                if (isFeet) {
+                if (isImperial) {
                     val feet = (distance * 3.280839895).roundToInt()
                     if (feet < 5280) {
-                        String.format("%d feet", feet)
+                        if (isAbbreviated) "%d ft".format(feet)
+                        else "%d %s".format(feet, if (feet == 1) "foot" else "feet")
                     } else {
-                        String.format("%d miles %d feet", feet / 5280, feet % 5280)
+                        val miles = feet / 5280
+                        val remainingFeet = feet % 5280
+                        if (isAbbreviated) "%d mi %d ft".format(miles, remainingFeet)
+                        else "%d %s %d %s".format(
+                            miles, if (miles == 1) "mile" else "miles",
+                            remainingFeet, if (remainingFeet == 1) "foot" else "feet"
+                        )
                     }
                 } else {
                     val meters = distance.roundToInt()
                     if (meters < 1000) {
-                        String.format("%d meters", meters)
+                        if (isAbbreviated) "%d m".format(meters)
+                        else "%d %s".format(meters, if (meters == 1) "meter" else "meters")
                     } else {
-                        String.format("%d km %d m", meters / 1000, meters % 1000)
+                        val km = meters / 1000
+                        val remainingMeters = meters % 1000
+                        "%d km %d m".format(km, remainingMeters)
                     }
                 }
             )


### PR DESCRIPTION
> [!IMPORTANT]
> Requires #264 to be merged

Improves the distance formatting in the `DistanceUtils.c()` hook:

- Respects the `isAbbreviated` flag (which was previously ignored) for both imperial and metric units. Metric was always partially abbreviated, imperial was not.
- Handles singular/plural correctly ("1 mile" instead of "1 miles", "1 foot" instead of "1 feet").
- Distances >= 1 km always use abbreviated format ("7 km 420 m"), as "7 kilometers 420 meters" is unnatural in everyday usage.

> [!NOTE]
>Based on observation, abbreviated format appears in Viewed me and Taps profile items, while full format appears in Profile details and chat headers.